### PR TITLE
feat: deploy to custom domain contract.onekeytest.com

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -6,16 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pages
   cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -38,18 +36,13 @@ jobs:
           npm install
           npm run build
 
-      - uses: actions/configure-pages@v4
+      - name: Add SPA fallback
+        run: cp deploy-app/dist/index.html deploy-app/dist/404.html
 
-      - uses: actions/upload-pages-artifact@v3
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: deploy-app/dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: deploy-app/dist
+          cname: contract.onekeytest.com
+          force_orphan: true

--- a/deploy-app/public/CNAME
+++ b/deploy-app/public/CNAME
@@ -1,0 +1,1 @@
+contract.onekeytest.com

--- a/deploy-app/vite.config.ts
+++ b/deploy-app/vite.config.ts
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/contracts/',
+  base: '/',
 })


### PR DESCRIPTION
## Summary
- Switch GitHub Pages deployment to custom domain `contract.onekeytest.com`
- Update Vite `base` from `/contracts/` to `/` for root-path serving
- Use `peaceiris/actions-gh-pages` with CNAME support and SPA 404 fallback

## TODO
- [ ] Configure DNS: CNAME record `contract.onekeytest.com` → `onekeyhq.github.io`
- [ ] GitHub repo Settings → Pages: set source to `gh-pages` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)